### PR TITLE
Modification of smartthings-hd-powerview to work (mostly) with gen2 hub.

### DIFF
--- a/devicetypes/johnvey/hunter-douglas-powerview-scene-collection.src/hunter-douglas-powerview-scene-collection.groovy
+++ b/devicetypes/johnvey/hunter-douglas-powerview-scene-collection.src/hunter-douglas-powerview-scene-collection.groovy
@@ -1,0 +1,131 @@
+/**
+ * Hunter Douglas PowerView Scene Collection (device handler)
+ * Copyright (c) 2017 Johnvey Hwang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// ----------------------------------------------------------------------------
+// configuration
+// ----------------------------------------------------------------------------
+
+metadata {
+    definition (
+        name: "Hunter Douglas PowerView Scene Collection", 
+        namespace: "johnvey", 
+        author: "Johnvey Hwang"
+    ) {
+        // tags
+        capability "Actuator"
+
+        // device capabilities
+        capability "Momentary"
+        capability "Switch"
+    }
+
+    tiles(scale: 2) {
+        standardTile("on", "device.windowShade", width: 3, height: 3,
+                    inactiveLabel: false, decoration: "flat") {
+            state("default", label:'Activate', action:"push",
+                icon:"st.switches.light.on")
+        }
+        main(["on"])
+    }
+}
+
+
+// ----------------------------------------------------------------------------
+// hub comm methods
+// ----------------------------------------------------------------------------
+
+/**
+ * Returns a unique id for deviceNetworkId uses; prefix must coordinate with
+ * the `getDeviceId()` method in powerview-manager.groovy
+ */
+private getDeviceId(pvId) {
+    return "scenecollection;${state.hubMAC};${pvId}"
+}
+
+private sendRequest(method, path, body=null) {
+    def host = "${state.hubIP}:${state.hubPort}"
+    def hubAction = new physicalgraph.device.HubAction(
+        [
+            method: method,
+            path: path,
+            HOST: host,
+            headers: [
+                'HOST': host,
+                'Content-Type': 'application/json'
+            ],
+            body: body
+        ],
+        getDeviceId(state.pvShadeId),
+        [
+            callback: sendRequestCallback
+        ]
+    )
+    // log.debug("sendRequest: ${method} ${host}${path}")
+    return hubAction
+}
+
+def sendRequestCallback(response) {
+    if (response.status != 200) {
+        log.warn("got unexpected response: status=${response.status} body=${response.body}")
+    }
+}
+
+
+// ----------------------------------------------------------------------------
+// app lifecycle hooks
+// ----------------------------------------------------------------------------
+
+def setHubInfo() {
+    state.hubMAC = parent.state.hubMAC
+    state.hubIP = parent.state.hubIP
+    state.hubPort = parent.state.hubPort
+    state.pvSceneCollectionId = device.name
+    log.debug("called setHubInfo() - hubMAC=${state.hubMAC} hubIP=${state.hubIP} hubPort=${state.hubPort} pvSceneId=${state.pvSceneCollectionId}")
+}
+
+// parse hub response into attributes
+def parse(String description) {
+    log.warn("parse() not implemented! Got: '${description}'")
+}
+
+def installed() {
+    log.info('CMD installed()')
+    setHubInfo()
+}
+
+def updated() {
+    log.info('CMD updated()')
+    setHubInfo()
+}
+
+// implement the momentary method
+def push() {
+    log.debug("CMD push()")
+    sendRequest("GET", "/api/scenecollections?sceneCollectionId=${state.pvSceneId}")
+}
+
+def on() {
+    log.debug("CMD on()")
+    return push()
+}
+
+def off() {
+    log.debug("CMD off()")
+    // pass
+}

--- a/devicetypes/johnvey/hunter-douglas-powerview-scene-collection.src/hunter-douglas-powerview-scene-collection.groovy
+++ b/devicetypes/johnvey/hunter-douglas-powerview-scene-collection.src/hunter-douglas-powerview-scene-collection.groovy
@@ -117,7 +117,7 @@ def updated() {
 // implement the momentary method
 def push() {
     log.debug("CMD push()")
-    sendRequest("GET", "/api/scenecollections?sceneCollectionId=${state.pvSceneId}")
+    sendRequest("GET", "/api/scenecollections?sceneCollectionId=${state.pvSceneCollectionId}")
 }
 
 def on() {

--- a/devicetypes/johnvey/hunter-douglas-powerview-scene.src/hunter-douglas-powerview-scene.groovy
+++ b/devicetypes/johnvey/hunter-douglas-powerview-scene.src/hunter-douglas-powerview-scene.groovy
@@ -117,7 +117,7 @@ def updated() {
 // implement the momentary method
 def push() {
     log.debug("CMD push()")
-    sendRequest("GET", "/api/scenes?sceneid=${state.pvSceneId}")
+    sendRequest("GET", "/api/scenes?sceneId=${state.pvSceneId}")
 }
 
 def on() {

--- a/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
+++ b/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
@@ -155,6 +155,7 @@ def getDeviceId(deviceType, pvId) {
     switch (deviceType) {
         case 'shade':
         case 'scene':
+        case 'scenecollection':
             // valid
             break
         default:
@@ -224,9 +225,16 @@ def _fetchAllShadesCallback(response) {
         def shadeConfig = it.clone()
 
         // add our custom keys
-        def shadeLabel = new String(it.name.decodeBase64())
+        def shadeLabel
+        try {
+          shadeLabel = new String(it.name.decodeBase64())
+        } catch (e) {
+          log.error "Error decoding shade ${it.id} with name ${it.name}"
+          log.error e
+          shadeLabel = "${it.id} ${it.name}"
+        }
         def enumLabel = "${shadeLabel} (${it.id})"
-        shadeConfig.label = shadeLabel // plain english name
+        shadeConfig.label = "Blind ${shadeLabel}" // plain english name
         shadeConfig.enumLabel = enumLabel // awkward label for use with prefs
         shadeConfig.deviceNetworkId = getDeviceId('shade', it.id)
 
@@ -278,11 +286,11 @@ def _fetchAllScenesCallback(response) {
         } catch (e) {
           log.error "Error decoding scene ${it.id} with name ${it.name}"
           log.error e
-          sceneLabel = "Scene ${it.id} ${it.name}"
+          sceneLabel = "${it.id} ${it.name}"
         }
 
         def enumLabel = "${sceneLabel} (${it.id})"
-        sceneConfig.label = sceneLabel // plain english name
+        sceneConfig.label = "Blinds ${sceneLabel}" // plain english name
         sceneConfig.enumLabel = enumLabel // awkward label for use with prefs
         sceneConfig.deviceNetworkId = getDeviceId('scene', it.id)
 
@@ -334,11 +342,11 @@ def _fetchAllSceneCollectionsCallback(response) {
         } catch (e) {
           log.error "Error decoding scene collection ${it.id} with name ${it.name}"
           log.error e
-          sceneCollectionLabel = "Scene collection ${it.id} ${it.name}"
+          sceneCollectionLabel = "${it.id} ${it.name}"
         }
 
         def enumLabel = "${sceneCollectionLabel} (${it.id})"
-        sceneCollectionConfig.label = sceneLabel // plain english name
+        sceneCollectionConfig.label = "Blinds ${sceneCollectionLabel}" // plain english name
         sceneCollectionConfig.enumLabel = enumLabel // awkward label for use with prefs
         sceneCollectionConfig.deviceNetworkId = getDeviceId('scenecollection', it.id)
 

--- a/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
+++ b/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
@@ -36,7 +36,7 @@ def singlePagePref() {
         name: "singlePagePref", 
         install: canInstall(), 
         uninstall: true, 
-        refreshInterval: getPrefInterval()
+        refreshInterval: 10
     ) {
         // setup basic connection to hub
         section("Hub setup") {
@@ -58,13 +58,21 @@ def singlePagePref() {
 
         // manage hub details
         if (hubIP) {
-            fetchHubInfo()
-            fetchAllShades()
-            fetchAllScenes()
             def foundShades = getDiscoveredShadeList()
             def foundScenes = getDiscoveredSceneList()
             def shadeCount = foundShades.size()
             def sceneCount = foundScenes.size()
+            if (!state.hubMAC) {
+              fetchHubInfo()
+            } else {
+	            if (shadeCount == 0) {
+    	          fetchAllShades()
+        	    } else {
+	    	        if (sceneCount == 0) {
+    	    	      fetchAllScenes()
+		            }
+                }
+            }
             log.info("pref.singlePagePref - shadeCount=$shadeCount, sceneCount=$sceneCount")
 
             section("Shades") {
@@ -104,13 +112,6 @@ def singlePagePref() {
 def canInstall() {
     return state.hubIP ? true : false
 }
-
-// TODO: should this back off the refresh rate if we have an IP?
-def getPrefInterval() {
-    return 5
-    // state.hubIP ? 5 : 15
-}
-
 
 // ----------------------------------------------------------------------------
 // utility methods
@@ -206,8 +207,8 @@ def _fetchAllShadesCallback(response) {
         def shadeConfig = it.clone()
 
         // add our custom keys
-        def shadeLabel = new String(it.name.decodeBase64())
-        def enumLabel = "${shadeLabel} (${it.id})"
+        def shadeLabel = new String(shadeConfig.name.decodeBase64())
+        def enumLabel = "${shadeLabel} (${shadeConfig.id})"
         shadeConfig.label = shadeLabel // plain english name
         shadeConfig.enumLabel = enumLabel // awkward label for use with prefs
         shadeConfig.deviceNetworkId = getDeviceId('shade', it.id)
@@ -254,8 +255,14 @@ def _fetchAllScenesCallback(response) {
         def sceneConfig = it.clone()
 
         // add our custom keys
-        def sceneLabel = new String(it.name.decodeBase64())
-        def enumLabel = "${sceneLabel} (${it.id})"
+        def sceneLabel
+        try {
+          sceneLabel = new String(sceneConfig.name.decodeBase64())
+        } catch (e) {
+          log.error "Error decoding scene ${sceneConfig.id} with name ${sceneConfig.name}"
+          log.error e
+        }
+        def enumLabel = "${sceneLabel} (${sceneConfig.id})"
         sceneConfig.label = sceneLabel // plain english name
         sceneConfig.enumLabel = enumLabel // awkward label for use with prefs
         sceneConfig.deviceNetworkId = getDeviceId('scene', it.id)

--- a/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
+++ b/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
@@ -254,7 +254,15 @@ def _fetchAllScenesCallback(response) {
         def sceneConfig = it.clone()
 
         // add our custom keys
-        def sceneLabel = new String(it.name.decodeBase64())
+        def sceneLabel
+        try {
+          sceneLabel = new String(sceneConfig.name.decodeBase64())
+        } catch (e) {
+          log.error "Error decoding scene ${sceneConfig.id} with name ${sceneConfig.name}"
+          log.error e
+          sceneLabel = "${it.id} ${it.name}"
+        }
+
         def enumLabel = "${sceneLabel} (${it.id})"
         sceneConfig.label = sceneLabel // plain english name
         sceneConfig.enumLabel = enumLabel // awkward label for use with prefs

--- a/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
+++ b/smartapps/johnvey/hunter-douglas-powerview.src/hunter-douglas-powerview.groovy
@@ -61,11 +61,14 @@ def singlePagePref() {
             fetchHubInfo()
             fetchAllShades()
             fetchAllScenes()
+            fetchAllSceneCollections()
             def foundShades = getDiscoveredShadeList()
             def foundScenes = getDiscoveredSceneList()
+            def foundSceneCollections = getDiscoveredSceneCollectionList()
             def shadeCount = foundShades.size()
             def sceneCount = foundScenes.size()
-            log.info("pref.singlePagePref - shadeCount=$shadeCount, sceneCount=$sceneCount")
+            def sceneCollectionCount = foundSceneCollections.size()
+            log.info("pref.singlePagePref - shadeCount=$shadeCount, sceneCount=$sceneCount, sceneCollectionCount=$sceneCollectionCount")
 
             section("Shades") {
                 if (shadeCount > 0) {
@@ -96,7 +99,22 @@ def singlePagePref() {
                     paragraph "Searching for installed scenes..."
                 }
             }
-        }
+
+            section("SceneCollections") {
+                if (sceneCollectionCount > 0) {
+                    input(
+                        name: "selectedSceneCollections", 
+                        title: "Linked scene collections (${sceneCollectionCount} available)", 
+                        type: "enum", 
+                        options: foundSceneCollections,
+                        multiple: true, 
+                        required: false
+                    )
+                } else {
+                    paragraph "Searching for installed scene collections..."
+                }
+            }
+		}
     }
 }
 
@@ -256,11 +274,11 @@ def _fetchAllScenesCallback(response) {
         // add our custom keys
         def sceneLabel
         try {
-          sceneLabel = new String(sceneConfig.name.decodeBase64())
+          sceneLabel = new String(it.name.decodeBase64())
         } catch (e) {
-          log.error "Error decoding scene ${sceneConfig.id} with name ${sceneConfig.name}"
+          log.error "Error decoding scene ${it.id} with name ${it.name}"
           log.error e
-          sceneLabel = "${it.id} ${it.name}"
+          sceneLabel = "Scene ${it.id} ${it.name}"
         }
 
         def enumLabel = "${sceneLabel} (${it.id})"
@@ -292,6 +310,61 @@ def sceneEnumToId(enumLabel) {
     return state.discoveredScenes[enumLabel]?.deviceNetworkId
 }
 
+/**
+ * Fetches all managed scene configs
+ */
+def fetchAllSceneCollections() {
+    return sendRequest('GET', '/api/scenecollections', null, _fetchAllSceneCollectionsCallback)
+}
+
+/**
+ * Handles response for scene configs
+ */
+def _fetchAllSceneCollectionsCallback(response) {
+    state.discoveredSceneCollections = [:]
+
+    response.json.sceneCollectionData?.each {
+        // start with the config info from PV
+        def sceneCollectionConfig = it.clone()
+
+        // add our custom keys
+        def sceneCollectionLabel
+        try {
+          sceneCollectionLabel = new String(it.name.decodeBase64())
+        } catch (e) {
+          log.error "Error decoding scene collection ${it.id} with name ${it.name}"
+          log.error e
+          sceneCollectionLabel = "Scene collection ${it.id} ${it.name}"
+        }
+
+        def enumLabel = "${sceneCollectionLabel} (${it.id})"
+        sceneCollectionConfig.label = sceneLabel // plain english name
+        sceneCollectionConfig.enumLabel = enumLabel // awkward label for use with prefs
+        sceneCollectionConfig.deviceNetworkId = getDeviceId('scenecollection', it.id)
+
+        state.discoveredSceneCollections[enumLabel] = sceneCollectionConfig
+    }
+	log.info "_fetchAllSceneCollectionsCallback(status=${response.status}) scenes=${state.discoveredSceneCollections.keySet()}"
+    return state.discoveredSceneCollections
+}
+
+/**
+ * Returns a flat list of scene names that can be rendered by a list control
+ */
+def getDiscoveredSceneCollectionList() {
+    def ret = []
+    state.discoveredSceneCollections?.each { key, value ->
+        ret.add(value.enumLabel)
+    }
+    return ret
+}
+
+/**
+ * Returns the device ID associated with an enumLabel
+ */
+def sceneCollectionEnumToId(enumLabel) {
+    return state.discoveredSceneCollections[enumLabel]?.deviceNetworkId
+}
 
 // ----------------------------------------------------------------------------
 // device handler methods
@@ -428,6 +501,76 @@ def removeAddedScenes() {
     state.addedSceneIds = []
 }
 
+/**
+ * Install the scene collections that the user selected in the config
+ */
+def installSelectedSceneCollections() {
+    log.info("installSelectedSceneCollections() selectedSceneCollections=${settings.selectedSceneCollections}")
+
+    // remove the scene collections that are installed but are not checked by the user
+    def toRemove = getDiscoveredSceneCollectionList() - settings.selectedSceneCollections
+    toRemove?.each {
+        def deviceId = sceneCollectionEnumToId(it)
+        log.info("Remove scene collection deviceId=$deviceId")
+        try {
+            deleteChildDevice(deviceId)
+        } catch (e) {
+            log.warn(e)
+        }
+    }
+
+    // iterate over the enum label
+    settings.selectedSceneCollections?.each {
+        installSceneCollection(it)
+    }
+}
+
+/**
+ * Installs an individual scene collection device handler
+ */
+def installSceneCollection(enumLabel) {
+    // get scene info already fetched
+    def sceneCollectionInfo = state.discoveredSceneCollections.get(enumLabel)
+    if (!sceneCollectionInfo) {
+        log.error("installSceneCollection failed; did not find $enumLabel in state.discoveredSceneCollections")
+        return
+    }
+
+    // check if device is already installed
+    def currentChildDevices = getChildDevices()
+    log.debug("current child devices: ${currentChildDevices}")
+    def selectedDevice = currentChildDevices.find { sceneCollectionInfo.deviceNetworkId }
+    def dev
+    if (selectedDevice) {
+        dev = getChildDevices()?.find {
+            it.deviceNetworkId == sceneCollectionInfo.deviceNetworkId
+        }
+    }
+
+    if (!dev) {
+        def addedDevice = addChildDevice(
+            "johnvey", 
+            "Hunter Douglas PowerView Scene Collection", 
+            sceneCollectionInfo.deviceNetworkId,
+            getHubID(),
+            [name: sceneCollectionInfo.id, label: sceneCollectionInfo.label, completedSetup: true]
+        )
+        // log the ID to the app for later use
+        state.addedSceneCollectionIds = state.addedSceneCollectionIds ?: []
+        state.addedSceneCollectionIds.add(sceneCollectionInfo.deviceNetworkId)
+        log.info "ADDED: label=${sceneCollectionInfo.label} deviceId=${sceneCollectionInfo.deviceNetworkId}"
+    } else {
+        log.debug("SKIP: deviceId=${sceneCollectionInfo.deviceNetworkId}")
+    }
+}
+
+def removeAddedSceneCollections() {
+    state.addedSceneCollectionIds?.each {
+        log.info("Remove scene collection deviceId=$it")
+        deleteChildDevice(it)
+    }
+    state.addedSceneCollectionIds = []
+}
 
 // ----------------------------------------------------------------------------
 // HTTP methods
@@ -476,6 +619,7 @@ def updated() {
     log.info "CMD updated"
     installSelectedShades()
     installSelectedScenes()
+    installSelectedSceneCollections()
 }
 
 /**


### PR DESCRIPTION
Effectively what I have done is changed the capitalization, and added support for "scene collections" in addition to scenes.  (Powerview calls them "multiroom scenes" but their api calls them "scene collections).  I did this in a somewhat janky way: just forked the scene device, and made minor tweaks.  I probably should have just added a "is multiroom" to the existing scene code, but .. meh.

With this patch I can control all my blinds scenes, but not my blinds individually.  I never did figure out what was happening in that area.